### PR TITLE
feat: add proof-of-concept for policy-driven PII sanitization pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.md
+__pycache__/
+.venv/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,71 @@
-# PII-Safe
-PII-Safe is a middleware and MCP compatible privacy plugin that automatically detects, redacts, or pseudonymizes personal data before it reaches an LLM or is stored in memory. The project aims to make agentic AI deployments safer, more compliant, and production-ready without compromising analytical value.
+# PII-Safe — Proof of Concept
+
+This POC demonstrates the core detection → policy evaluation → sanitization loop.
+It is scoped to prove that the design works end-to-end, not to be production-ready.
+
+## What this shows
+
+- **Policy engine** (`policy.py`): loads `policy.yaml` and resolves the action (`allow`, `redact`, `pseudonymize`, `block`) for any entity type in any operation context.
+- **Sanitizer** (`sanitizer.py`): wraps Presidio's Analyzer, applies per-instance pseudonymization with session-scoped consistency, and produces an audit trail.
+- **Service layer** (`main.py`): exposes the same core logic via both a FastMCP tool (`/mcp`) and a FastAPI REST endpoint (`/sanitize`), with optional transparent HTTP middleware.
+
+## Setup
+
+```bash
+pip install -r requirements.txt
+python -m spacy download en_core_web_lg
+```
+
+## Run the demo (no server needed)
+
+```bash
+python demo.py
+```
+
+Expected output covers four scenarios:
+1. `analysis` context — emails/names pseudonymized, credit card redacted
+2. Session consistency — same email returns the same token within a session
+3. New session — token counter resets, same email gets `EMAIL_01` again
+4. `export` context — request blocked because emails are forbidden in this context
+
+## Run the server
+
+```bash
+uvicorn main:app --reload
+```
+
+Then try the REST endpoint:
+
+```bash
+curl -X POST http://localhost:8000/sanitize \
+  -H "Content-Type: application/json" \
+  -d '{
+    "content": "Contact john@example.com or call 555-867-5309.",
+    "operation": "analysis",
+    "session_id": "incident-42"
+  }'
+```
+
+Or use the transparent middleware by adding the opt-in header to any request:
+
+```bash
+curl -X POST http://localhost:8000/any-endpoint \
+  -H "X-PII-Safe-Context: analysis" \
+  -H "X-PII-Safe-Session: incident-42" \
+  -H "Content-Type: application/json" \
+  -d '{"message": "Send this to bob@example.com"}'
+```
+
+The MCP server is available at `http://localhost:8000/mcp` for any MCP-compatible client.
+
+## File structure
+
+```
+poc/
+  policy.yaml      ← privacy rules as auditable config (the core innovation)
+  policy.py        ← YAML loader + action resolver
+  sanitizer.py     ← Presidio pipeline + session-scoped pseudonymization
+  main.py          ← FastAPI app + FastMCP server (one process, two protocols)
+  demo.py          ← runnable end-to-end demo (no server required)
+  requirements.txt
+```

--- a/demo.py
+++ b/demo.py
@@ -1,0 +1,91 @@
+"""
+demo.py — End-to-end demonstration of the PII-Safe pipeline.
+
+Run with:  python demo.py
+
+No server needed — calls the core sanitize() function directly.
+Demonstrates four scenarios that cover the key design decisions
+discussed in the GitHub issue.
+"""
+from pathlib import Path
+from policy import load_policy
+from sanitizer import sanitize
+
+policy = load_policy(Path(__file__).parent / "policy.yaml")
+
+DIVIDER = "-" * 60
+
+
+def show(label: str, result):
+    print(f"\n  Sanitized : {result.sanitized_content}")
+    print(f"  Risk score: {result.risk_score:.2f}")
+    for e in result.entities_found:
+        print(f"  [{e.action.upper():14s}] {e.entity_type} (conf={e.confidence:.2f}) → {e.replacement or '(kept)'}")
+    if result.token_map_ref:
+        print(f"  Token map ref: {result.token_map_ref}")
+
+
+# ---------------------------------------------------------------------------
+# Scenario 1: analysis context — pseudonymize names/emails, redact card/phones
+# ---------------------------------------------------------------------------
+print(f"\n{DIVIDER}")
+print("SCENARIO 1: context='analysis'")
+print("Emails and names → pseudonymized (consistent tokens)")
+print("Credit card and Phone numbers → redacted")
+
+print(DIVIDER)
+
+text1 = (
+    "Hi, I'm John Smith. My email is john@example.com "
+    "and my card number is 4111 1111 1111 1111."
+)
+print(f"\n  Input: {text1}")
+result1 = sanitize(text1, context="analysis", policy=policy, session_id="incident-42")
+show("analysis", result1)
+
+
+# ---------------------------------------------------------------------------
+# Scenario 2: session consistency — same email in same session → same token
+# ---------------------------------------------------------------------------
+print(f"\n{DIVIDER}")
+print("SCENARIO 2: session consistency (session='incident-42')")
+print("john@example.com should still be EMAIL_01 from Scenario 1")
+print(DIVIDER)
+
+text2 = "Please follow up with sara@example.com and john@example.com."
+print(f"\n  Input: {text2}")
+result2 = sanitize(text2, context="analysis", policy=policy, session_id="incident-42")
+show("analysis, same session", result2)
+
+
+# ---------------------------------------------------------------------------
+# Scenario 3: different session — tokens restart from _01
+# ---------------------------------------------------------------------------
+print(f"\n{DIVIDER}")
+print("SCENARIO 3: different session (session='incident-99')")
+print("New email should now be EMAIL_01 — fresh session, fresh tokens")
+print(DIVIDER)
+
+text3 = "Contact alex@example.com about this."
+print(f"\n  Input: {text3}")
+result3 = sanitize(text3, context="analysis", policy=policy, session_id="incident-99")
+show("analysis, new session", result3)
+
+
+# ---------------------------------------------------------------------------
+# Scenario 4: export context — emails and phones are blocked
+# ---------------------------------------------------------------------------
+print(f"\n{DIVIDER}")
+print("SCENARIO 4: context='export' — block action raises ValueError")
+print("Emails are set to 'block' in the export policy")
+print(DIVIDER)
+
+text4 = "Export this report to external@partner.com."
+print(f"\n  Input: {text4}")
+try:
+    result4 = sanitize(text4, context="export", policy=policy, session_id="export-1")
+    show("export", result4)
+except ValueError as e:
+    print(f"\n  BLOCKED: {e}")
+
+print(f"\n{DIVIDER}\n")

--- a/main.py
+++ b/main.py
@@ -1,0 +1,201 @@
+"""
+main.py — PII-Safe service: FastAPI middleware + MCP server in one process.
+
+Both interfaces share the same core sanitize() function from sanitizer.py.
+The FastMCP server is mounted onto FastAPI as a sub-application, so a single
+`uvicorn main:app` starts everything.
+
+Interfaces:
+  - MCP tool:        POST /mcp  (for AI agents — explicit tool call)
+  - REST endpoint:   POST /sanitize  (direct HTTP access)
+  - HTTP middleware:  transparent — opt-in via X-PII-Safe-Context header
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from fastapi import FastAPI, Request
+from fastmcp import FastMCP
+from pydantic import BaseModel
+from typing import Literal
+
+from policy import load_policy
+from sanitizer import sanitize, SanitizeResult
+
+# ---------------------------------------------------------------------------
+# Load policy once at startup — shared by all interfaces
+# ---------------------------------------------------------------------------
+
+POLICY_PATH = Path(__file__).parent / "policy.yaml"
+policy_config = load_policy(POLICY_PATH)
+
+# ---------------------------------------------------------------------------
+# Pydantic models
+# ---------------------------------------------------------------------------
+
+class PIISafeRequest(BaseModel):
+    content: str
+    content_type: Literal["text", "json", "log"] = "text"
+    operation: str = "analysis"        # maps to a policy context
+    session_id: str = "default"
+    policy_id: str | None = None       # reserved for multi-policy support
+
+
+class AuditEntryOut(BaseModel):
+    entity_type: str
+    original_span: tuple[int, int]
+    action: str
+    replacement: str | None
+    confidence: float
+
+
+class PIISafeResponse(BaseModel):
+    sanitized_content: str
+    risk_score: float
+    entities_found: list[AuditEntryOut]
+    token_map_ref: str | None
+    audit_id: str
+
+
+# ---------------------------------------------------------------------------
+# FastAPI app
+# ---------------------------------------------------------------------------
+
+app = FastAPI(
+    title="PII-Safe",
+    description="Privacy Guard for Agentic AI & MCP Workflows",
+    version="0.1.0-poc",
+)
+
+
+# --- REST endpoint ---
+
+@app.post("/sanitize", response_model=PIISafeResponse)
+async def sanitize_endpoint(req: PIISafeRequest) -> PIISafeResponse:
+    """Sanitize PII in text according to the policy for the given operation context."""
+    result: SanitizeResult = sanitize(
+        text=req.content,
+        context=req.operation,
+        policy=policy_config,
+        session_id=req.session_id,
+    )
+    return PIISafeResponse(
+        sanitized_content=result.sanitized_content,
+        risk_score=result.risk_score,
+        entities_found=[
+            AuditEntryOut(
+                entity_type=e.entity_type,
+                original_span=e.original_span,
+                action=e.action,
+                replacement=e.replacement,
+                confidence=e.confidence,
+            )
+            for e in result.entities_found
+        ],
+        token_map_ref=result.token_map_ref,
+        audit_id=result.audit_id,
+    )
+
+
+# --- Transparent HTTP middleware ---
+# Opt-in: send header  X-PII-Safe-Context: analysis  (or export, storage, etc.)
+# Sanitizes all top-level string values in JSON request bodies before they
+# reach any downstream handler.
+
+@app.middleware("http")
+async def pii_middleware(request: Request, call_next):
+    pii_context = request.headers.get("X-PII-Safe-Context")
+    if not pii_context:
+        # Header absent — pass through unchanged
+        return await call_next(request)
+
+    body_bytes = await request.body()
+    try:
+        body = json.loads(body_bytes)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        # Non-JSON body — pass through unchanged
+        return await call_next(request)
+
+    session_id = request.headers.get("X-PII-Safe-Session", "default")
+
+    def _sanitize_value(obj):
+        """Recursively sanitize all string values in a JSON structure."""
+        if isinstance(obj, str):
+            return sanitize(obj, pii_context, policy_config, session_id).sanitized_content
+        if isinstance(obj, dict):
+            return {k: _sanitize_value(v) for k, v in obj.items()}
+        if isinstance(obj, list):
+            return [_sanitize_value(item) for item in obj]
+        return obj
+
+    sanitized_body = _sanitize_value(body)
+    sanitized_bytes = json.dumps(sanitized_body).encode()
+
+    # Rebuild request with sanitized body so downstream handlers never see raw PII
+    async def _receive():
+        return {"type": "http.request", "body": sanitized_bytes}
+
+    request._receive = _receive
+    return await call_next(request)
+
+
+# ---------------------------------------------------------------------------
+# FastMCP server — mounted at /mcp
+# ---------------------------------------------------------------------------
+
+mcp = FastMCP(name="pii-safe")
+
+
+@mcp.tool
+def sanitize_pii(
+    text: str,
+    session_id: str = "default",
+    context: str = "analysis",
+) -> dict:
+    """
+    Detect and sanitize PII in text before sending it to an LLM or external service.
+
+    Returns sanitized text, a list of detected entities with their actions,
+    and a privacy risk score between 0.0 (no PII) and 1.0 (high risk).
+
+    Use session_id to group related calls — the same raw value will always
+    receive the same pseudonym token within a session.
+
+    Context options: "analysis" (block SSN, pseudonymize emails/names, redact cards/phones)
+                     "export"   (block SSN/cards/emails/phones, redact names/IPs)
+    """
+    result: SanitizeResult = sanitize(
+        text=text,
+        context=context,
+        policy=policy_config,
+        session_id=session_id,
+    )
+    return {
+        "sanitized_text": result.sanitized_content,
+        "risk_score": result.risk_score,
+        "entities_found": [
+            {
+                "entity_type": e.entity_type,
+                "span": list(e.original_span),
+                "action": e.action,
+                "replacement": e.replacement,
+                "confidence": round(e.confidence, 3),
+            }
+            for e in result.entities_found
+        ],
+        "token_map_ref": result.token_map_ref,
+        "audit_id": result.audit_id,
+    }
+
+
+# Mount MCP server onto FastAPI — one process, two protocols
+app.mount("/mcp", mcp.http_app)
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8000, reload=False)

--- a/policy.py
+++ b/policy.py
@@ -1,0 +1,64 @@
+"""
+policy.py — YAML policy loader and action resolver.
+
+This is PII-Safe's core innovation: privacy rules as auditable config,
+not hardcoded Python. A security team can read and edit policy.yaml
+without touching application code.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+import yaml
+
+# The four possible actions a policy rule can assign to an entity.
+Action = Literal["allow", "redact", "pseudonymize", "block"]
+
+DEFAULT_ACTION: Action = "allow"
+
+
+@dataclass
+class PolicyConfig:
+    """Loaded and parsed representation of policy.yaml."""
+    entity_weights: dict[str, int]
+    # rules: context -> entity_type -> action
+    # e.g. rules["analysis"]["EMAIL_ADDRESS"] == "pseudonymize"
+    rules: dict[str, dict[str, Action]]
+
+
+def load_policy(path: str | Path = "policy.yaml") -> PolicyConfig:
+    """
+    Parse a policy YAML file into a PolicyConfig.
+    Raises FileNotFoundError if the file doesn't exist.
+    """
+    with open(path) as f:
+        data = yaml.safe_load(f)
+
+    rules: dict[str, dict[str, Action]] = {}
+    for policy in data.get("policies", []):
+        context: str = policy["context"]
+        rules[context] = {}
+        for rule in policy.get("rules", []):
+            rules[context][rule["entity"]] = rule["action"]
+
+    return PolicyConfig(
+        entity_weights=data.get("entity_weights", {}),
+        rules=rules,
+    )
+
+
+def get_action(config: PolicyConfig, context: str, entity_type: str) -> Action:
+    """
+    Return the action for an entity type in a given operation context.
+
+    Falls back to DEFAULT_ACTION ("allow") if:
+    - the context is not defined in the policy, or
+    - the entity type has no rule in that context.
+
+    This means new entity types are safe by default (allowed through)
+    rather than silently blocked — a deliberate choice to avoid breaking
+    pipelines when new detectors are added.
+    """
+    return config.rules.get(context, {}).get(entity_type, DEFAULT_ACTION)

--- a/policy.yaml
+++ b/policy.yaml
@@ -1,0 +1,46 @@
+version: "1.0"
+
+# Risk weights per entity type — contributes to the 0.0–1.0 exposure score.
+# Auditable here so security teams can adjust without touching code.
+entity_weights:
+  US_SSN: 10
+  CREDIT_CARD: 10
+  EMAIL_ADDRESS: 5
+  PHONE_NUMBER: 5
+  PERSON: 3
+  IP_ADDRESS: 3
+
+# Policies define how each entity type is handled per operation context.
+# Actions: allow | redact | pseudonymize | block
+policies:
+  - name: internal_analysis
+    context: analysis
+    rules:
+      - entity: US_SSN
+        action: block
+      - entity: CREDIT_CARD
+        action: redact
+      - entity: EMAIL_ADDRESS
+        action: pseudonymize
+      - entity: PHONE_NUMBER
+        action: redact
+      - entity: PERSON
+        action: pseudonymize
+      - entity: IP_ADDRESS
+        action: allow
+
+  - name: external_export
+    context: export
+    rules:
+      - entity: US_SSN
+        action: block
+      - entity: CREDIT_CARD
+        action: block
+      - entity: EMAIL_ADDRESS
+        action: block
+      - entity: PHONE_NUMBER
+        action: block
+      - entity: PERSON
+        action: redact
+      - entity: IP_ADDRESS
+        action: redact

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+fastapi==0.135.2
+fastmcp==3.1.1
+presidio_analyzer==2.2.359
+pydantic==2.12.5
+uvicorn==0.42.0

--- a/sanitizer.py
+++ b/sanitizer.py
@@ -1,0 +1,196 @@
+"""
+sanitizer.py — Presidio detection pipeline with session-scoped pseudonymization.
+
+This module wraps Presidio's Analyzer (detection) and applies policy-driven
+actions per entity instance. It is the only module that touches Presidio directly —
+everything else interacts through the sanitize() function.
+
+Key design note on pseudonymization:
+  Presidio's built-in operators apply a single replacement value per *entity type*,
+  which means all emails in a text would become the same token. We handle
+  pseudonymization manually (replacing spans from end-to-start to preserve offsets)
+  so that distinct values within the same type each get their own unique, consistent
+  token: john@a.com → EMAIL_01, sara@b.com → EMAIL_02.
+"""
+from __future__ import annotations
+
+import hashlib
+import uuid
+from dataclasses import dataclass, field
+
+from presidio_analyzer import AnalyzerEngine
+
+from policy import PolicyConfig, get_action, Action
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+@dataclass
+class AuditEntry:
+    entity_type: str
+    original_span: tuple[int, int]
+    action: str
+    replacement: str | None
+    confidence: float          # Presidio's detection confidence (0.0–1.0)
+
+
+@dataclass
+class SanitizeResult:
+    sanitized_content: str
+    risk_score: float          # 0.0–1.0
+    entities_found: list[AuditEntry]
+    token_map_ref: str | None  # session_id, present only if pseudonymization was used
+    audit_id: str = field(default_factory=lambda: str(uuid.uuid4()))
+
+
+# ---------------------------------------------------------------------------
+# Session-scoped token map (in-memory for POC; production uses SQLite)
+#
+# Structure:
+#   _token_map[session_id][(entity_type, raw_hash)] = "EMAIL_01"
+#   _counters[session_id][entity_type] = 2   ← next counter value
+#
+# The raw value is *never* stored — only its SHA-256 prefix.
+# ---------------------------------------------------------------------------
+
+_token_map: dict[str, dict[tuple[str, str], str]] = {}
+_counters: dict[str, dict[str, int]] = {}
+
+
+def _get_pseudonym(session_id: str, entity_type: str, raw_value: str) -> str:
+    """
+    Return a stable, human-readable pseudonym for a (session, entity, value) triple.
+
+    Within a session, the same raw value always returns the same token.
+    Different values of the same entity type get incrementing numbers:
+      john@example.com  → EMAIL_01
+      sara@example.com  → EMAIL_02
+      john@example.com  → EMAIL_01  (seen again — same token)
+    """
+    raw_hash = hashlib.sha256(raw_value.encode()).hexdigest()[:16]
+
+    if session_id not in _token_map:
+        _token_map[session_id] = {}
+        _counters[session_id] = {}
+
+    key = (entity_type, raw_hash)
+    if key not in _token_map[session_id]:
+        count = _counters[session_id].get(entity_type, 0) + 1
+        _counters[session_id][entity_type] = count
+        _token_map[session_id][key] = f"{entity_type}_{count:02d}"
+
+    return _token_map[session_id][key]
+
+
+# ---------------------------------------------------------------------------
+# Presidio setup
+# ---------------------------------------------------------------------------
+
+# Entity types PII-Safe supports in this POC.
+# Matches the types defined in policy.yaml
+SUPPORTED_ENTITIES = [
+    "US_SSN",
+    "CREDIT_CARD",
+    "EMAIL_ADDRESS",
+    "PHONE_NUMBER",
+    "PERSON",
+    "IP_ADDRESS",
+]
+
+# AnalyzerEngine is expensive to initialise (loads spaCy model).
+# Instantiate once at module load; reuse across all requests.
+_analyzer = AnalyzerEngine()
+
+
+# ---------------------------------------------------------------------------
+# Core sanitize function
+# ---------------------------------------------------------------------------
+
+def sanitize(
+    text: str,
+    context: str,
+    policy: PolicyConfig,
+    session_id: str = "default",
+) -> SanitizeResult:
+    """
+    Run the full detection → policy evaluation → sanitization pipeline.
+
+    Steps:
+      1. Detect all PII entities via Presidio Analyzer.
+      2. Evaluate each entity against the policy for the given context.
+      3. Raise immediately if any entity triggers a "block" action.
+      4. Apply per-instance replacements (end-to-start to preserve offsets).
+      5. Compute a weighted risk score.
+
+    Args:
+        text:       Raw input text.
+        context:    Operation context (e.g. "analysis", "export").
+        policy:     Loaded PolicyConfig from policy.yaml.
+        session_id: Groups pseudonym mappings for consistency across requests.
+
+    Returns:
+        SanitizeResult with sanitized text, risk score, and audit trail.
+
+    Raises:
+        ValueError: If any detected entity type is set to "block" in this context.
+    """
+    # Step 1 — detect
+    results = _analyzer.analyze(
+        text=text,
+        language="en",
+        entities=SUPPORTED_ENTITIES,
+    )
+
+    # Step 2 & 3 — evaluate policy, fail fast on block
+    for result in results:
+        action: Action = get_action(policy, context, result.entity_type)
+        if action == "block":
+            raise ValueError(
+                f"Request blocked: entity type '{result.entity_type}' "
+                f"is not permitted in context '{context}'."
+            )
+
+    # Step 4 — apply replacements from end-to-start so earlier offsets stay valid
+    sorted_results = sorted(results, key=lambda r: r.start, reverse=True)
+    sanitized = text
+    audit_entries: list[AuditEntry] = []
+    used_pseudonymization = False
+
+    for result in sorted_results:
+        action = get_action(policy, context, result.entity_type)
+        raw_value = text[result.start:result.end]
+
+        if action == "redact":
+            replacement = f"<{result.entity_type}>"
+        elif action == "pseudonymize":
+            replacement = _get_pseudonym(session_id, result.entity_type, raw_value)
+            used_pseudonymization = True
+        else:
+            # allow — leave the span untouched
+            replacement = None
+
+        if replacement is not None:
+            sanitized = sanitized[: result.start] + replacement + sanitized[result.end :]
+
+        audit_entries.append(
+            AuditEntry(
+                entity_type=result.entity_type,
+                original_span=(result.start, result.end),
+                action=action,
+                replacement=replacement,
+                confidence=result.score,
+            )
+        )
+
+    # Step 5 — risk score: sum of entity weights, normalised to 0.0–1.0, capped at 1.0
+    weights = policy.entity_weights
+    risk_raw = sum(weights.get(e.entity_type, 1) for e in audit_entries)
+    risk_score = min(1.0, risk_raw / 100)
+
+    return SanitizeResult(
+        sanitized_content=sanitized,
+        risk_score=risk_score,
+        entities_found=audit_entries,
+        token_map_ref=session_id if used_pseudonymization else None,
+    )


### PR DESCRIPTION
## What this PR proves

This is the proof-of-concept PR for the design discussed in #18 . It is intentionally scoped — no persistence, no Redis, no auth — to validate the core design decisions before building the full system.

## The three claims it validates

**1. Policy-as-YAML works**
`policy.yaml` drives all sanitization behavior. Changing a rule requires editing the YAML file, not touching Python. A security
auditor can read and approve the policy without reading code.

**2. Session-scoped pseudonymization is consistent**
`john@example.com` maps to `EMAIL_01` for the lifetime of a session. A new session resets the counter. Critical for incident analysis (correlate across events) without exposing real PII.

**3. One process, two protocols**
FastAPI and FastMCP share the same `sanitize()` core. The MCP tool and the REST endpoint produce identical output.

## How to run it

```bash
pip install -r requirements.txt
python -m spacy download en_core_web_lg
python demo.py   # no server needed, covers all 4 scenarios
```

## What this is NOT

- Not production-ready
- No SQLite persistence yet (tokens are in-memory)
- No Redis caching yet
- No authentication for de-anonymization yet

All of the above are planned for subsequent PRs per the proposal timeline.

## Questions

- Does the `block` action raising a `ValueError` feel right, or should it return a structured error response instead?
- Is the `risk_score` calculation (weighted sum, capped at 100) aligned with what you had in mind?